### PR TITLE
Introduce support for custom callbacks, various fixes and improvements

### DIFF
--- a/sem/__init__.py
+++ b/sem/__init__.py
@@ -4,11 +4,11 @@ from .parallelrunner import ParallelRunner
 from .lptrunner import LptRunner
 from .gridrunner import BUILD_GRID_PARAMS, SIMULATION_GRID_PARAMS
 from .database import DatabaseManager
-from .utils import list_param_combinations, automatic_parser, stdout_automatic_parser, only_load_some_files
+from .utils import list_param_combinations, automatic_parser, stdout_automatic_parser, only_load_some_files, CallbackBase
 from .cli import cli
 
 __all__ = ('CampaignManager', 'SimulationRunner', 'ParallelRunner', 'LptRunner',
            'DatabaseManager', 'list_param_combinations', 'automatic_parser',
-           'only_load_some_files')
+           'only_load_some_files', 'CallbackBase')
 
 name = 'sem'

--- a/sem/manager.py
+++ b/sem/manager.py
@@ -305,6 +305,10 @@ class CampaignManager(object):
                 can be either a string or a number).
             show_progress (bool): whether or not to show a progress bar with
                 percentage and expected remaining time.
+            callbacks (list): list of objects extending CallbackBase to be 
+                triggered during the run.
+            stop_on_errors (bool): whether or not to stop the execution of the simulations 
+                if an error occurs.
         """
 
         # Make sure we have a runner to run simulations with.
@@ -315,7 +319,7 @@ class CampaignManager(object):
                             " for this CampaignManager.")
 
         # Return if the list is empty
-        if param_list == []:
+        if not param_list:
             return
 
         self.check_and_fill_parameters(param_list, needs_rngrun=True)
@@ -378,8 +382,7 @@ class CampaignManager(object):
         self.db.insert_results(results_batch)
         self.db.write_to_disk()
 
-    def get_missing_simulations(self, param_list, runs=None,
-                                with_time_estimate=False):
+    def get_missing_simulations(self, param_list, runs=None, with_time_estimate=False):
         """
         Return a list of the simulations among the required ones that are not
         available in the database.
@@ -390,6 +393,7 @@ class CampaignManager(object):
             runs (int): an integer representing how many repetitions are wanted
                 for each parameter combination, None if the dictionaries in
                 param_list already feature the desired RngRun value.
+            with_time_estimate (bool): a boolean representing ...
         """
 
         params_to_simulate = []
@@ -452,6 +456,7 @@ class CampaignManager(object):
 
     def run_missing_simulations(self, param_list, runs=None,
                                 condition_checking_function=None,
+                                callbacks=[],
                                 stop_on_errors=True):
         """
         Run the simulations from the parameter list that are not yet available
@@ -471,6 +476,10 @@ class CampaignManager(object):
             runs (int): the number of runs to perform for each parameter
                 combination. This parameter is only allowed if the param_list
                 specification doesn't feature an 'RngRun' key already.
+            callbacks (list): list of objects extending CallbackBase to be 
+                triggered during the run.
+            stop_on_errors (bool): whether or not to stop the execution of the simulations 
+                if an error occurs.
         """
         # Expand the parameter specification
         param_list = list_param_combinations(param_list)
@@ -504,10 +513,12 @@ class CampaignManager(object):
                     self.get_missing_simulations(param_list,
                                                  runs,
                                                  with_time_estimate=True),
+                    callbacks=callbacks,
                     stop_on_errors=stop_on_errors)
             else:
                 self.run_simulations(
                     self.get_missing_simulations(param_list, runs),
+                    callbacks=callbacks,
                     stop_on_errors=stop_on_errors)
 
     #####################

--- a/sem/manager.py
+++ b/sem/manager.py
@@ -290,7 +290,7 @@ class CampaignManager(object):
     # Simulation running #
     ######################
 
-    def run_simulations(self, param_list, show_progress=True, stop_on_errors=True):
+    def run_simulations(self, param_list, show_progress=True, callbacks: list = [], stop_on_errors=True):
         """
         Run several simulations specified by a list of parameter combinations.
 
@@ -339,6 +339,7 @@ class CampaignManager(object):
         # computation is performed on this line.
         results = self.runner.run_simulations(param_list,
                                               self.db.get_data_dir(),
+                                              callbacks=callbacks,
                                               stop_on_errors=stop_on_errors)
 
         # Wrap the result generator in the progress bar generator.

--- a/sem/parallelrunner.py
+++ b/sem/parallelrunner.py
@@ -19,6 +19,7 @@ class ParallelRunner(SimulationRunner):
 
         for cb in callbacks:
             cb.on_simulation_start(len(list(enumerate(parameter_list))))
+            cb.controlled_by_parent = True
 
         self.data_folder = data_folder
         self.stop_on_errors = stop_on_errors

--- a/sem/parallelrunner.py
+++ b/sem/parallelrunner.py
@@ -1,25 +1,33 @@
 from .runner import SimulationRunner
-from multiprocessing import Pool
-
+from .utils import CallbackBase
+from multiprocessing.pool import ThreadPool as Pool
+# We use ThreadPool to share the process memory among the different simulations to enable the use of callbacks.
+# This may be improved eventually using a grain-fined solution that checks the presence or not of callbacks
 
 class ParallelRunner(SimulationRunner):
 
     """
     A Runner which can perform simulations in parallel on the current machine.
     """
+    data_folder: str = None
+    stop_on_errors: bool = False
+    callbacks: [CallbackBase] = []
 
-    def run_simulations(self, parameter_list, data_folder, callbacks: list = [], stop_on_errors=False):
+    def run_simulations(self, parameter_list, data_folder, callbacks: [CallbackBase] = None, stop_on_errors=False):
         """
         This function runs multiple simulations in parallel.
 
         Args:
             parameter_list (list): list of parameter combinations to simulate.
             data_folder (str): folder in which to create output folders.
+            callbacks (list): list of callbacks to be triggered
+            stop_on_errors (bool): check whether simulation has to stop on errors or not
         """
-
-        for cb in callbacks:
-            cb.on_simulation_start(len(list(enumerate(parameter_list))))
-            cb.controlled_by_parent = True
+        
+        if callbacks is not None:
+            for cb in callbacks:
+                cb.on_simulation_start(len(list(enumerate(parameter_list))))
+                cb.controlled_by_parent = True
 
         self.data_folder = data_folder
         self.stop_on_errors = stop_on_errors
@@ -29,10 +37,11 @@ class ParallelRunner(SimulationRunner):
                                               parameter_list):
                 yield result
 
-        for cb in callbacks:
-            cb.on_simulation_end()
+        if callbacks is not None:
+            for cb in callbacks:
+                cb.on_simulation_end()
 
-    def launch_simulation(self, parameter, callbacks: list = []):
+    def launch_simulation(self, parameter):
         """
         Launch a single simulation, using SimulationRunner's facilities.
 

--- a/sem/parallelrunner.py
+++ b/sem/parallelrunner.py
@@ -18,14 +18,14 @@ class ParallelRunner(SimulationRunner):
         """
 
         for cb in callbacks:
-            cb.on_simulation_start(len(enumerate(parameter_list)))
+            cb.on_simulation_start(len(list(enumerate(parameter_list))))
 
         self.data_folder = data_folder
         self.stop_on_errors = stop_on_errors
+        self.callbacks = callbacks
         with Pool(processes=self.max_parallel_processes) as pool:
             for result in pool.imap_unordered(self.launch_simulation,
-                                              parameter_list,
-                                              callbacks):
+                                              parameter_list):
                 yield result
 
         for cb in callbacks:
@@ -43,5 +43,5 @@ class ParallelRunner(SimulationRunner):
         """
         return next(SimulationRunner.run_simulations(self, [parameter],
                                                      self.data_folder,
-                                                     callbacks=callbacks,
+                                                     callbacks=self.callbacks,
                                                      stop_on_errors=self.stop_on_errors))

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -301,8 +301,10 @@ class SimulationRunner(object):
                 simulation output.
         """
         
+        # Log simulation start if not already done by parent class
         for cb in callbacks:
-            cb.on_simulation_start(len(enumerate(parameter_list)))
+            if not cb.is_controlled_by_parent():
+                cb.on_simulation_start(len(enumerate(parameter_list)))
 
         for _, parameter in enumerate(parameter_list):
 
@@ -366,6 +368,8 @@ class SimulationRunner(object):
             current_result['meta']['exitcode'] = return_code
 
             yield current_result
-
+        
+        # Log simulation start if not already done by parent class
         for cb in callbacks:
-            cb.on_simulation_end(return_code, end-start)
+            if not cb.is_controlled_by_parent():
+                cb.on_simulation_end()

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -301,15 +301,10 @@ class SimulationRunner(object):
                 simulation output.
         """
         
-<<<<<<< HEAD
         # Log simulation start if not already done by parent class
         for cb in callbacks:
             if not cb.is_controlled_by_parent():
                 cb.on_simulation_start(len(enumerate(parameter_list)))
-=======
-        for cb in callbacks:
-            cb.on_simulation_start(len(enumerate(parameter_list)))
->>>>>>> 35bf57f0e9cc11476eb264700f00b2f65c7779e2
 
         for _, parameter in enumerate(parameter_list):
 
@@ -373,14 +368,8 @@ class SimulationRunner(object):
             current_result['meta']['exitcode'] = return_code
 
             yield current_result
-<<<<<<< HEAD
         
         # Log simulation start if not already done by parent class
         for cb in callbacks:
             if not cb.is_controlled_by_parent():
                 cb.on_simulation_end()
-=======
-
-        for cb in callbacks:
-            cb.on_simulation_end(return_code, end-start)
->>>>>>> 35bf57f0e9cc11476eb264700f00b2f65c7779e2

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -72,7 +72,7 @@ class SimulationRunner(object):
             build_status_fname = ".lock-ns3_%s_build" % sys.platform
             build_status_path = os.path.join(path, build_status_fname)
         else:
-            build_status_fname = "build-status.py"
+            build_status_fname = "build.py"
             if optimized:
                 build_status_path = os.path.join(path,
                                                 'build/optimized/build-status.py')
@@ -289,7 +289,7 @@ class SimulationRunner(object):
     # Simulation running #
     ######################
 
-    def run_simulations(self, parameter_list, data_folder, stop_on_errors=False):
+    def run_simulations(self, parameter_list, data_folder, callbacks: list = [], stop_on_errors=False):
         """
         Run several simulations using a certain combination of parameters.
 
@@ -300,6 +300,9 @@ class SimulationRunner(object):
             data_folder (str): folder in which to save subfolders containing
                 simulation output.
         """
+        
+        for cb in callbacks:
+            cb.on_simulation_start(len(enumerate(parameter_list)))
 
         for _, parameter in enumerate(parameter_list):
 
@@ -321,6 +324,10 @@ class SimulationRunner(object):
             start = time.time()  # Time execution
             stdout_file_path = os.path.join(temp_dir, 'stdout')
             stderr_file_path = os.path.join(temp_dir, 'stderr')
+
+            for cb in callbacks:
+                cb.on_run_start()
+
             with open(stdout_file_path, 'w') as stdout_file, open(
                     stderr_file_path, 'w') as stderr_file:
                 return_code = subprocess.call(command, cwd=temp_dir,
@@ -329,7 +336,11 @@ class SimulationRunner(object):
                                               stderr=stderr_file)
             end = time.time()  # Time execution
 
+            for cb in callbacks:
+                cb.on_run_end(return_code, end-start)
+
             if return_code != 0:
+
                 with open(stdout_file_path, 'r') as stdout_file, open(
                         stderr_file_path, 'r') as stderr_file:
                     complete_command = sem.utils.get_command_from_result(self.script, current_result)
@@ -349,9 +360,12 @@ class SimulationRunner(object):
                                         complete_command_debug))
                     if stop_on_errors:
                         raise Exception(error_message)
-                    print(error_message)
+                    print(error_message) 
 
             current_result['meta']['elapsed_time'] = end-start
             current_result['meta']['exitcode'] = return_code
 
             yield current_result
+
+        for cb in callbacks:
+            cb.on_simulation_end(return_code, end-start)

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -72,6 +72,7 @@ class SimulationRunner(object):
             build_status_fname = ".lock-ns3_%s_build" % sys.platform
             build_status_path = os.path.join(path, build_status_fname)
         else:
+            build_status_fname = "build.py"
             if optimized:
                 build_status_path = os.path.join(path,
                                                 'build/optimized/build-status.py')
@@ -288,7 +289,7 @@ class SimulationRunner(object):
     # Simulation running #
     ######################
 
-    def run_simulations(self, parameter_list, data_folder, stop_on_errors=False):
+    def run_simulations(self, parameter_list, data_folder, callbacks: list = [], stop_on_errors=False):
         """
         Run several simulations using a certain combination of parameters.
 
@@ -299,6 +300,9 @@ class SimulationRunner(object):
             data_folder (str): folder in which to save subfolders containing
                 simulation output.
         """
+        
+        for cb in callbacks:
+            cb.on_simulation_start(len(enumerate(parameter_list)))
 
         for _, parameter in enumerate(parameter_list):
 
@@ -320,6 +324,10 @@ class SimulationRunner(object):
             start = time.time()  # Time execution
             stdout_file_path = os.path.join(temp_dir, 'stdout')
             stderr_file_path = os.path.join(temp_dir, 'stderr')
+
+            for cb in callbacks:
+                cb.on_run_start()
+
             with open(stdout_file_path, 'w') as stdout_file, open(
                     stderr_file_path, 'w') as stderr_file:
                 return_code = subprocess.call(command, cwd=temp_dir,
@@ -328,7 +336,11 @@ class SimulationRunner(object):
                                               stderr=stderr_file)
             end = time.time()  # Time execution
 
+            for cb in callbacks:
+                cb.on_run_end(return_code, end-start)
+
             if return_code != 0:
+
                 with open(stdout_file_path, 'r') as stdout_file, open(
                         stderr_file_path, 'r') as stderr_file:
                     complete_command = sem.utils.get_command_from_result(self.script, current_result)
@@ -348,9 +360,12 @@ class SimulationRunner(object):
                                         complete_command_debug))
                     if stop_on_errors:
                         raise Exception(error_message)
-                    print(error_message)
+                    print(error_message) 
 
             current_result['meta']['elapsed_time'] = end-start
             current_result['meta']['exitcode'] = return_code
 
             yield current_result
+
+        for cb in callbacks:
+            cb.on_simulation_end(return_code, end-start)

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -304,7 +304,7 @@ class SimulationRunner(object):
         # Log simulation start if not already done by parent class
         for cb in callbacks:
             if not cb.is_controlled_by_parent():
-                cb.on_simulation_start(len(enumerate(parameter_list)))
+                cb.on_simulation_start(len(list(enumerate(parameter_list))))
 
         for _, parameter in enumerate(parameter_list):
 

--- a/sem/utils.py
+++ b/sem/utils.py
@@ -326,12 +326,17 @@ class CallbackBase(ABC):
 
     def init_callback(self, controlled_by_parent) -> None:
         """
-        Initialize the callbacke.
+        Initialize the callback.
         """
         self.controlled_by_parent = controlled_by_parent
         self._init_callback()
 
     def is_controlled_by_parent(self) -> bool:
+        """
+        Whether this runner is aware of all simulations (false)
+        or it has been triggered by a multithread runner and is thus
+        aware of a subset of all runs only (true).
+        """
         return self.controlled_by_parent
 
     def on_simulation_start(self, n_runs_total) -> None:

--- a/sem/utils.py
+++ b/sem/utils.py
@@ -316,6 +316,7 @@ class CallbackBase(ABC):
     def __init__(self, verbose: int = 0):
         super().__init__()
         # Number of time the callback was called
+        self.controlled_by_parent = False
         self.n_runs_over = 0  # type: int
         self.n_runs_over_no_errors = 0  # type: int
         self.n_runs_over_errors = 0  # type: int
@@ -323,11 +324,15 @@ class CallbackBase(ABC):
         self.run_sim_times = []
         self.verbose = verbose
 
-    def init_callback(self) -> None:
+    def init_callback(self, controlled_by_parent) -> None:
         """
         Initialize the callbacke.
         """
+        self.controlled_by_parent = controlled_by_parent
         self._init_callback()
+
+    def is_controlled_by_parent(self) -> bool:
+        return self.controlled_by_parent
 
     def on_simulation_start(self, n_runs_total) -> None:
         self.n_runs_total = n_runs_total

--- a/sem/utils.py
+++ b/sem/utils.py
@@ -316,10 +316,7 @@ class CallbackBase(ABC):
     def __init__(self, verbose: int = 0):
         super().__init__()
         # Number of time the callback was called
-<<<<<<< HEAD
         self.controlled_by_parent = False
-=======
->>>>>>> 35bf57f0e9cc11476eb264700f00b2f65c7779e2
         self.n_runs_over = 0  # type: int
         self.n_runs_over_no_errors = 0  # type: int
         self.n_runs_over_errors = 0  # type: int
@@ -327,7 +324,6 @@ class CallbackBase(ABC):
         self.run_sim_times = []
         self.verbose = verbose
 
-<<<<<<< HEAD
     def init_callback(self, controlled_by_parent) -> None:
         """
         Initialize the callbacke.
@@ -338,14 +334,6 @@ class CallbackBase(ABC):
     def is_controlled_by_parent(self) -> bool:
         return self.controlled_by_parent
 
-=======
-    def init_callback(self) -> None:
-        """
-        Initialize the callbacke.
-        """
-        self._init_callback()
-
->>>>>>> 35bf57f0e9cc11476eb264700f00b2f65c7779e2
     def on_simulation_start(self, n_runs_total) -> None:
         self.n_runs_total = n_runs_total
         self._on_simulation_start()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from sem import list_param_combinations, automatic_parser, stdout_automatic_parser
+from sem import list_param_combinations, automatic_parser, stdout_automatic_parser, CallbackBase, CampaignManager
 import json
 import numpy as np
 from operator import getitem
@@ -101,3 +101,41 @@ def test_automatic_parser(result):
                                        [6, 7, 8, 9, 10]])
     assert parsed['stderr'] == []
 
+
+class TestCallback(CallbackBase):
+
+    # Prevent pytest from trying to collect this function as a test
+    __test__ = False
+
+    def __init__(self):
+        CallbackBase.__init__(self, verbose=2)
+        self.output = ''
+
+    def _on_simulation_start(self) -> None:
+        self.output += 'Starting the simulations!\n'
+
+    def _on_simulation_end(self) -> None:
+        self.output += 'Simulations are over!\n'
+
+    def _on_run_start(self, configuration: dict, sim_uuid: str) -> None:
+        self.output += 'Start single run!\n'
+
+    def _on_run_end(self, sim_uuid: str, return_code: int, sim_time: int) -> bool:
+        self.output += f'Run ended! {return_code}\n'
+        return True
+
+
+def test_callback(ns_3_compiled, config, parameter_combination):
+    cb = TestCallback()
+    n_runs = 10
+    expected_output = 'Starting the simulations!\n' + \
+        f'Start single run!\nRun ended! {0}\n' * \
+        n_runs + 'Simulations are over!\n'
+
+    campaign = CampaignManager.new(ns_3_compiled, config['script'], config['campaign_dir'],
+                                   runner_type='SimulationRunner', overwrite=True)
+    parameter_combination.update({'RngRun': [
+        run for run in range(n_runs)]})
+    campaign.run_missing_simulations(
+        param_list=[parameter_combination], callbacks=[cb])
+    assert expected_output == cb.output


### PR DESCRIPTION
This PR adds the support for defining custom callbacks, with the main use case in mind the notification of simulation progress, for instance via a Telegram bot.
The base callback class is inspired by [stable-baselines3](https://stable-baselines3.readthedocs.io/en/master/_modules/stable_baselines3/common/callbacks.html)

Moreover:
- Switched to `ThreadPool` to `Pool` to support callbacks as member variables
- Improved documentation coverage